### PR TITLE
Project Update and FCEUX Bugfix

### DIFF
--- a/Bheithir.csproj
+++ b/Bheithir.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/emulators/Fceux.cs
+++ b/emulators/Fceux.cs
@@ -11,7 +11,7 @@ namespace Bheithir.Emulators
         public Fceux()
         {
             DiscordAppId = "693692813321437247";
-            ProcessName = "fcuex";
+            ProcessName = "fceux";
             WindowPattern = new Regex("(:\\s)+", RegexOptions.Compiled);
         }
 


### PR DESCRIPTION
- Binaries compiled with .NET5.0 did not run out-of-the-box due to End of Support for .NET5.0. Should run with .NET8.0 on Windows with Microsoft Updates. Alternatives to resolve this would be AOT or Standalone.
- Fixed FCEUX detection-breaking string -- `fcuex` => `fceux`.